### PR TITLE
Removed unnecessary dependency on 'dcos' in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
         'docopt',
-        'dcos',
     ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
Without this, running `make env` fails in the last step.